### PR TITLE
Add pre-commit config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__
 dist
 build
 *.pyc
+.idea/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,10 +18,10 @@ repos:
     rev: '22.6.0'
     hooks:
       - id: black
-  - repo: https://github.com/PyCQA/flake8
-    rev: '5.0.2'
-    hooks:
-      - id: flake8
+#  - repo: https://github.com/PyCQA/flake8
+#    rev: '5.0.2'
+#    hooks:
+#      - id: flake8
   - repo: https://github.com/PyCQA/doc8
     rev: 'v1.0.0'
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,37 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: 'v4.3.0'
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+      - id: check-ast
+      - id: fix-byte-order-marker
+      - id: check-case-conflict
+      - id: check-merge-conflict
+      - id: detect-private-key
+      - id: mixed-line-ending
+  - repo: https://github.com/psf/black
+    rev: '22.6.0'
+    hooks:
+      - id: black
+  - repo: https://github.com/PyCQA/flake8
+    rev: '5.0.2'
+    hooks:
+      - id: flake8
+  - repo: https://github.com/PyCQA/doc8
+    rev: 'v1.0.0'
+    hooks:
+      - id: doc8
+  - repo: https://github.com/PyCQA/isort
+    rev: '5.10.1'
+    hooks:
+      - id: isort
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v2.37.3
+    hooks:
+      - id: pyupgrade
+        args: [ --py36-plus ]


### PR DESCRIPTION
Using a pre-commit config together with https://pre-commit.ci/ , we can get rid of all byte-order markers and missing newlines at the end of files and anachronistic python constructs automatically, so we will never again have a bug like #21.

In this PR, I have only included the config itself, not the changes it would generate. If you want to see the changes yourself, run `pre-commit run --all-files` in a checkout of this branch. If you think it is a good idea, enable https://pre-commit.ci/ for this repo and the changes will be added automatically to the next PR (or maybe already to this PR, I don't know).