### PR TITLE
fix: include LICENSE file in distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,4 +25,4 @@ requires = ["uv_build>=0.11.1,<0.12"]
 build-backend = "uv_build"
 
 [tool.uv.build-backend]
-source-include = ["README.md", "globalwarmingpotentials.csv"]
+source-include = ["README.md", "globalwarmingpotentials.csv", "LICENSE"]


### PR DESCRIPTION
It is best practice to include the LICENSE file in the distribution so users can easily find the licensing information in the installed package. Also, it makes it easier for downstreams (I noticed the missing file when preparing the conda release).